### PR TITLE
适配 3.x 配置文件

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,7 +14,6 @@ class PreprocessPlugin(BasePlugin):
     @handler(PromptPreProcessing)
     async def _(self, ctx: EventContext):
 
-        import pkg.config
         import datetime
         import re
 

--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ class PreprocessPlugin(BasePlugin):
     @handler(PromptPreProcessing)
     async def _(self, ctx: EventContext):
 
-        import config
+        import pkg.config
         import datetime
         import re
 


### PR DESCRIPTION
修复了在 3.x 因配置文件调整导致的插件无法使用的问题