### PR TITLE
修复替换逻辑

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,7 +14,6 @@ class PreprocessPlugin(BasePlugin):
     @handler(PromptPreProcessing)
     async def _(self, ctx: EventContext):
 
-        import config
         import datetime
         import re
 

--- a/main.py
+++ b/main.py
@@ -1,9 +1,9 @@
 from pkg.plugin.context import register, handler, llm_func, BasePlugin, APIHost, EventContext
 from pkg.plugin.events import *  # 导入事件类
-
+import copy
 
 # 注册插件
-@register(name="Preprocessor", description="预处理prompt：嵌入当前时间、使用的模型等信息。", version="0.1.0", author="RockChinQ")
+@register(name="Preprocessor", description="预处理prompt：嵌入当前时间、使用的模型等信息。", version="0.2.0", author="RockChinQ")
 class PreprocessPlugin(BasePlugin):
 
     # 插件加载时触发
@@ -17,21 +17,27 @@ class PreprocessPlugin(BasePlugin):
         import datetime
         import re
 
-        local_default_prompt = ctx.event.default_prompt.copy()
+        local_default_prompt = copy.deepcopy(ctx.event.default_prompt)
+        processed_prompt = copy.deepcopy(local_default_prompt)
 
-        mapping = {
-            "model": ctx.event.query.use_model.name,
-            # yyyy-mm-dd hh:mm:ss day
-            "date_now": datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S %a"),
-        }
-
-        for round in local_default_prompt:
+        for round, processed_round in zip(local_default_prompt, processed_prompt):
+            
+            mapping = {
+                "model": ctx.event.query.use_model.name,
+                # yyyy-mm-dd hh:mm:ss day
+                "date_now": datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S %a"),
+            }
+            
             # 把 round['content'] 中的 $key 替换为 mapping[key]
             for key in mapping:
-                round.content = re.sub(r"\$"+key, mapping[key], round.content)
-
+                processed_round.content = re.sub(r"\$"+key, mapping[key], processed_round.content)
+                
+            # 在替换完成后恢复占位符以保证可重复使用
+            for key in mapping:
+                round.content = re.sub(re.escape(mapping[key]), f"${key}", round.content)
+                
         ctx.add_return(
-            "default_prompt", local_default_prompt
+            "default_prompt", processed_prompt
         )
 
         # event.prevent_postorder()


### PR DESCRIPTION
这个东西其实已经破案了，，
原因如下：
- 占位符与在第一次运行后已被替换，导致第二次运行时没有占位符可供替换

- 动态值未更新，导致第二次运行时仍然使用第一次生成的值

针对这两个问题，进行了修复
- 将mapping放入循环内，以重新生成mapping

- 加入了占位符恢复逻辑，调整返回逻辑

现在终于可以优雅的重复调用此插件了，bot终于有了准确的时间观念

能够参与贡献，乃荣幸之至